### PR TITLE
Separate out debug page from main page

### DIFF
--- a/environment-mac.yml
+++ b/environment-mac.yml
@@ -2,7 +2,8 @@ name: waisn-tech-tools
 channels:
   - defaults
 dependencies:
-  - ca-certificates=2018.12.5=0
+  - beautifulsoup4=4.7.1=py37_1
+  - ca-certificates=2019.1.23=0
   - certifi=2018.11.29=py37_0
   - django=2.1.4=py37_0
   - factory_boy=2.11.1=py37_0
@@ -20,9 +21,11 @@ dependencies:
   - readline=7.0=h1de35cc_5
   - setuptools=40.6.3=py37_0
   - six=1.12.0=py37_0
+  - soupsieve=1.7.1=py37_0
   - sqlite=3.25.3=ha441bb4_0
   - text-unidecode=1.2=py37_0
   - tk=8.6.8=ha441bb4_0
   - wheel=0.32.3=py37_0
   - xz=5.2.4=h1de35cc_4
   - zlib=1.2.11=h1de35cc_3
+

--- a/waisntechtools/alerts/templates/alerts/debug.html
+++ b/waisntechtools/alerts/templates/alerts/debug.html
@@ -1,0 +1,11 @@
+{% load static %}
+
+<h1>Debug Page</h1>
+
+<br/>
+
+<ul>
+    {% for subscriber in subscribers %}
+    <li>{{ subscriber }}</li>
+    {% endfor %}
+</ul>

--- a/waisntechtools/alerts/templates/alerts/index.html
+++ b/waisntechtools/alerts/templates/alerts/index.html
@@ -4,10 +4,4 @@
 
 <br/>
 
-<img src="{% static "alerts/WAISN-logo.jpg" %}" />
-
-<ul>
-{% for subscriber in subscribers %}
-    <li>{{ subscriber }}</li>
-{% endfor %}
-</ul>
+<img src="{% static 'alerts/WAISN-logo.jpg' %}" />

--- a/waisntechtools/alerts/urls.py
+++ b/waisntechtools/alerts/urls.py
@@ -1,8 +1,10 @@
+from django.shortcuts import render
 from django.urls import path
 
 from . import views
 
 app_name = 'alerts'
 urlpatterns = [
-    path('', views.IndexView.as_view(), name='index')
+    path('', lambda request: render(request, 'alerts/index.html'), name='index'),
+    path('debug', views.DebugView.as_view(), name='debug')
 ]

--- a/waisntechtools/alerts/views.py
+++ b/waisntechtools/alerts/views.py
@@ -3,9 +3,9 @@ from django.views.generic import ListView
 from alerts.models import Subscriber
 
 
-class IndexView(ListView):
+class DebugView(ListView):
     model = Subscriber
-    template_name = 'alerts/index.html'
+    template_name = 'alerts/debug.html'
     context_object_name = 'subscribers'
 
     def get_queryset(self):


### PR DESCRIPTION
[Problem]
The debug information is cluttering the main page.

[Solution]
Separate out the debug information into its own separate view.

[Test]
* Unit tests
* Manually verified both index and debug pages