### PR TITLE
Add Auth0 integration

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,3 +42,23 @@ To see commands specific to the project, e.g. seeding, run:
 ```
 python manage.py
 ```
+
+# Running the Server
+
+There are a few environment settings that need to be enabled to run the server. The reason for this is because the
+website is protected using Auth0. Hence the following environment variables need to be declared. Note that the Auth0
+application should be configured to be a **Regular Web Application**.
+
+* `AUTH0_DOMAIN`: The Auth0 application's domain
+* `AUTH0_KEY`: The Auth0 application's client id
+* `AUTH0_SECRET`: The Auth0 application's client secret.
+
+## Disabling Auth0
+
+Runnning the service locally without access to the internet requires authentication to be disabled. This can be done by
+setting the environment variable:
+
+```
+# disable Auth0 login requirement
+export WAISN_AUTH_DISABLED='TRUE'
+```

--- a/environment-mac.yml
+++ b/environment-mac.yml
@@ -2,21 +2,31 @@ name: waisn-tech-tools
 channels:
   - defaults
 dependencies:
+  - asn1crypto=0.24.0=py37_0
   - beautifulsoup4=4.7.1=py37_1
   - ca-certificates=2019.1.23=0
-  - certifi=2018.11.29=py37_0
+  - certifi=2019.3.9=py37_0
+  - cffi=1.12.3=py37hb5b8e2f_0
+  - cryptography=2.6.1=py37ha12b0ac_0
   - django=2.1.4=py37_0
+  - ecdsa=0.13=py37_1
   - factory_boy=2.11.1=py37_0
   - faker=1.0.1=py37_0
+  - future=0.17.1=py37_0
+  - gmp=6.1.2=hb37e062_1
   - libcxx=4.0.1=hcfea43d_1
   - libcxxabi=4.0.1=hcfea43d_1
   - libedit=3.1.20170329=hb402a30_2
   - libffi=3.2.1=h475c297_4
   - ncurses=6.1=h0a44026_1
-  - openssl=1.1.1a=h1de35cc_0
+  - openssl=1.1.1b=h1de35cc_1
   - pip=18.1=py37_0
+  - pyasn1=0.4.5=py_0
+  - pycparser=2.19=py37_0
+  - pycryptodome=3.7.3=py37ha8bbb54_0
   - python=3.7.1=haf84260_7
   - python-dateutil=2.7.5=py37_0
+  - python-jose=3.0.1=py_0
   - pytz=2018.7=py37_0
   - readline=7.0=h1de35cc_5
   - setuptools=40.6.3=py37_0
@@ -28,4 +38,16 @@ dependencies:
   - wheel=0.32.3=py37_0
   - xz=5.2.4=h1de35cc_4
   - zlib=1.2.11=h1de35cc_3
-
+  - pip:
+    - chardet==3.0.4
+    - defusedxml==0.6.0
+    - idna==2.8
+    - oauthlib==3.0.1
+    - pyjwt==1.7.1
+    - python-dotenv==0.10.2
+    - python3-openid==3.1.0
+    - requests==2.22.0
+    - requests-oauthlib==1.2.0
+    - social-auth-app-django==3.1.0
+    - social-auth-core==3.1.0
+    - urllib3==1.25.3

--- a/waisntechtools/alerts/auth0backend.py
+++ b/waisntechtools/alerts/auth0backend.py
@@ -1,0 +1,36 @@
+from urllib import request
+from jose import jwt
+from social_core.backends.oauth import BaseOAuth2
+
+
+class Auth0(BaseOAuth2):
+    """Auth0 OAuth authentication backend"""
+    name = 'auth0'
+    SCOPE_SEPARATOR = ' '
+    ACCESS_TOKEN_METHOD = 'POST'
+    EXTRA_DATA = [
+        ('picture', 'picture')
+    ]
+
+    def authorization_url(self):
+        return 'https://' + self.setting('DOMAIN') + '/authorize'
+
+    def access_token_url(self):
+        return 'https://' + self.setting('DOMAIN') + '/oauth/token'
+
+    def get_user_id(self, details, response):
+        """Return current user id."""
+        return details['user_id']
+
+    def get_user_details(self, response):
+        # Obtain JWT and the keys to validate the signature
+        id_token = response.get('id_token')
+        jwks = request.urlopen('https://' + self.setting('DOMAIN') + '/.well-known/jwks.json')
+        issuer = 'https://' + self.setting('DOMAIN') + '/'
+        audience = self.setting('KEY')  # CLIENT_ID
+        payload = jwt.decode(id_token, jwks.read(), algorithms=['RS256'], audience=audience, issuer=issuer)
+
+        return {'username': payload['nickname'],
+                'first_name': payload['name'],
+                'picture': payload['picture'],
+                'user_id': payload['sub']}

--- a/waisntechtools/alerts/templates/alerts/base.html
+++ b/waisntechtools/alerts/templates/alerts/base.html
@@ -1,0 +1,44 @@
+<!doctype html>
+<html lang="en">
+<head>
+    <!-- Required meta tags -->
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
+    <!-- JS needed for bootstrap -->
+    <script src="https://code.jquery.com/jquery-3.3.1.slim.min.js" integrity="sha384-q8i/X+965DzO0rT7abK41JStQIAqVgRVzpbzo5smXKp4YfRvH+8abtTE1Pi6jizo" crossorigin="anonymous"></script>
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/popper.js/1.14.7/umd/popper.min.js" integrity="sha384-UO2eT0CpHqdSJQ6hJty5KVphtPhzWj9WO1clHTMGa3JDZwrnQq4sF86dIHNDz0W1" crossorigin="anonymous"></script>
+    <!-- Bootstrap CSS & JS -->
+    <link rel="stylesheet" href="https://stackpath.bootstrapcdn.com/bootstrap/4.3.1/css/bootstrap.min.css" integrity="sha384-ggOyR0iXCbMQv3Xipma34MD+dH/1fQ784/j6cY/iJTQUOhcWr7x9JvoRxT2MZw1T" crossorigin="anonymous">
+    <script src="https://stackpath.bootstrapcdn.com/bootstrap/4.3.1/js/bootstrap.min.js" integrity="sha384-JjSmVgyd0p3pXB1rRibZUAYoIIy6OrQ6VrjIEaFf/nJGzIxFDsf4x0xIM+B07jRM" crossorigin="anonymous"></script>
+    <!-- Bootswatch for sick dark theme -->
+    <link rel="stylesheet" href="https://bootswatch.com/4/darkly/bootstrap.min.css">
+    <title>WAISN Tech Tools</title>
+</head>
+<body>
+<nav class="navbar navbar-expand-lg navbar-light bg-light mb-3">
+    <div class="container">
+        <a class="navbar-brand" href="/">WAISN Tech Tools</a>
+        <button class="navbar-toggler" type="button" data-toggle="collapse" data-target="#navbarSupportedContent"
+                aria-controls="navbarSupportedContent" aria-expanded="false" aria-label="Toggle navigation">
+            <span class="navbar-toggler-icon"></span>
+        </button>
+        <div class="collapse navbar-collapse" id="navbarSupportedContent">
+            <ul class="navbar-nav mr-auto">
+                <li class="nav-item"><a class="nav-link" href="/">Home</a></li>
+                <li><a class="nav-link" href="{% url 'alerts:debug' %}">Debug</a></li>
+                {% if request.user.is_authenticated == False %}
+                    <li class="nav-item"><a class="nav-link" href="/login/auth0">Log In</a></li>
+                {% endif %}
+                {% if request.user.is_authenticated == True %}
+                    <li class="nav-item"><a class="nav-link" href="/logout">Log Out</a></li>
+                {% endif %}
+            </ul>
+        </div>
+    </div>
+</nav>
+<div class="container px-2">
+    {% block content %}i
+    {% endblock %}
+</div>
+</body>
+</html>

--- a/waisntechtools/alerts/templates/alerts/debug.html
+++ b/waisntechtools/alerts/templates/alerts/debug.html
@@ -1,11 +1,11 @@
-{% load static %}
+{% extends 'alerts/base.html' %}
 
-<h1>Debug Page</h1>
-
-<br/>
-
-<ul>
-    {% for subscriber in subscribers %}
-    <li>{{ subscriber }}</li>
-    {% endfor %}
-</ul>
+{% block content %}
+    <h1>Debug Page</h1>
+    <br/>
+    <ul>
+        {% for subscriber in subscribers %}
+        <li>{{ subscriber }}</li>
+        {% endfor %}
+    </ul>
+{% endblock %}

--- a/waisntechtools/alerts/templates/alerts/index.html
+++ b/waisntechtools/alerts/templates/alerts/index.html
@@ -1,7 +1,8 @@
+{% extends 'alerts/base.html' %}
 {% load static %}
 
-<h1>Welcome to the WAISN Alert System</h1>
-
-<br/>
-
-<img src="{% static 'alerts/WAISN-logo.jpg' %}" />
+{% block content %}
+    <h1>Welcome to the WAISN Alert System</h1>
+    <br/>
+    <img src="{% static 'alerts/WAISN-logo.jpg' %}" />
+{% endblock %}

--- a/waisntechtools/alerts/urls.py
+++ b/waisntechtools/alerts/urls.py
@@ -1,10 +1,9 @@
-from django.shortcuts import render
 from django.urls import path
 
-from . import views
+from alerts import views
 
 app_name = 'alerts'
 urlpatterns = [
-    path('', lambda request: render(request, 'alerts/index.html'), name='index'),
-    path('debug', views.DebugView.as_view(), name='debug')
+    path('', views.index, name='index'),
+    path('debug', views.debug, name='debug'),
 ]

--- a/waisntechtools/alerts/views.py
+++ b/waisntechtools/alerts/views.py
@@ -1,6 +1,18 @@
+from django.shortcuts import render
 from django.views.generic import ListView
 
 from alerts.models import Subscriber
+from alerts.waisn_auth import waisn_auth
+
+
+@waisn_auth
+def index(request):
+    return render(request, 'alerts/index.html')
+
+
+@waisn_auth
+def debug(request):
+    return DebugView.as_view()(request)
 
 
 class DebugView(ListView):

--- a/waisntechtools/alerts/waisn_auth.py
+++ b/waisntechtools/alerts/waisn_auth.py
@@ -1,0 +1,23 @@
+from functools import wraps
+from os import environ
+
+from django.contrib.auth.decorators import login_required
+
+from waisntechtools.settings import DEBUG
+
+_AUTH_DISABLED_KEY = 'WAISN_AUTH_DISABLED'
+_AUTH_DISABLED_VALUE = 'TRUE'
+
+
+def waisn_auth(view_func):
+    """
+    Decorator for views that performs authentication. Authentication can be disabled based on the environment settings.
+    """
+    @wraps(view_func)
+    def _waisn_auth_decorator(request, *args, **kwargs):
+        if _AUTH_DISABLED_KEY in environ and environ[_AUTH_DISABLED_KEY] == _AUTH_DISABLED_VALUE and DEBUG:
+            return view_func(request)
+        else:
+            return login_required()(view_func)(request, *args, **kwargs)
+
+    return _waisn_auth_decorator

--- a/waisntechtools/waisntechtools/settings.py
+++ b/waisntechtools/waisntechtools/settings.py
@@ -11,6 +11,7 @@ https://docs.djangoproject.com/en/2.1/ref/settings/
 """
 
 import os
+from os import environ
 
 # Build paths inside the project like this: os.path.join(BASE_DIR, ...)
 BASE_DIR = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
@@ -38,6 +39,7 @@ INSTALLED_APPS = [
     'django.contrib.sessions',
     'django.contrib.messages',
     'django.contrib.staticfiles',
+    'social_django',
 ]
 
 MIDDLEWARE = [
@@ -119,3 +121,23 @@ USE_TZ = True
 # https://docs.djangoproject.com/en/2.1/howto/static-files/
 
 STATIC_URL = '/static/'
+
+# BEGIN Auth0
+SOCIAL_AUTH_TRAILING_SLASH = False  # Remove trailing slash from routes
+SOCIAL_AUTH_AUTH0_DOMAIN = environ['AUTH0_DOMAIN']
+SOCIAL_AUTH_AUTH0_KEY = environ['AUTH0_KEY']
+SOCIAL_AUTH_AUTH0_SECRET = environ['AUTH0_SECRET']
+SOCIAL_AUTH_AUTH0_SCOPE = [
+    'openid',
+    'profile'
+]
+
+AUTHENTICATION_BACKENDS = {
+    'alerts.auth0backend.Auth0',
+    'django.contrib.auth.backends.ModelBackend'
+}
+
+LOGIN_URL = '/login/auth0'
+LOGIN_REDIRECT_URL = '/'
+LOGOUT_REDIRECT_URL = '/'
+# END Auth0

--- a/waisntechtools/waisntechtools/urls.py
+++ b/waisntechtools/waisntechtools/urls.py
@@ -13,12 +13,27 @@ Including another URLconf
     1. Import the include() function: from django.urls import include, path
     2. Add a URL to urlpatterns:  path('blog/', include('blog.urls'))
 """
-from django.contrib import admin
-from django.urls import path, include
+from urllib.parse import urlencode
+
+from django.conf import settings
+from django.contrib.auth import logout as log_out
+from django.http import HttpResponseRedirect
+from django.urls import include, path
 from django.views.generic import RedirectView
+
+
+def logout(request):
+    log_out(request)
+    return_to = urlencode({'returnTo': request.build_absolute_uri('/')})
+    logout_url = 'https://%s/v2/logout?client_id=%s&%s' % \
+                 (settings.SOCIAL_AUTH_AUTH0_DOMAIN, settings.SOCIAL_AUTH_AUTH0_KEY, return_to)
+    return HttpResponseRedirect(logout_url)
+
 
 urlpatterns = [
     path('', RedirectView.as_view(url='alerts')),
     path('alerts/', include('alerts.urls')),
-    path('admin/', admin.site.urls),
+    path('logout', logout),
+    path('', include('django.contrib.auth.urls')),
+    path('', include('social_django.urls')),
 ]


### PR DESCRIPTION
[Problem]
Need authentication capabilities for the WAISN tech server.

[Solution]
Integrate with Auth0 and allow disabling authentication via environment settings. Note that the **Log In** button still
exists even with authentication turned off and will redirect you to Auth0. The button could be removed, but I don't
think we want the test and production UI's to look different.

[Test]
* `python manage.py test`
* set authentication on and logged in and out via Auth0
* set authentication off and authentication was not required

In the future, end-2-end tests could be used to automate this using selenium or cypress.